### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ ADD classy /src/classy
 RUN pip install -e /src
 
 ENV TZ America/Los_Angeles
-ENV CLASSY_CONFIG docker_config.py
+ENV CLASSY_CONFIG /src/config.py
 USER nobody:nogroup
 CMD ["gunicorn", "--bind", ":8000", "classy.app:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:2.7
+
+RUN pip install gunicorn
+
+ADD requirements.txt /src/requirements.txt
+RUN pip install -r /src/requirements.txt
+
+ADD setup.py /src/setup.py
+ADD classy /src/classy
+RUN pip install -e /src
+
+ENV TZ America/Los_Angeles
+ENV CLASSY_CONFIG docker_config.py
+USER nobody:nogroup
+CMD ["gunicorn", "--bind", ":8000", "classy.app:app"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,29 @@ Running
 Note that the path to the configuration file in `CLASSY_CONFIG`
 is relative to the package directory (./classy in this example).
 
+Docker
+----
+
+### Building a docker image
+
+    # docker build --tag=classy .
+
+This builds a docker image containing classy and all its dependencies.
+
+### Running the docker container
+
+    # docker run -p 5001:8000 -e CLASSY_CLIENT_ID=xxx -e CLASSY_CLIENT_SECRET=xxx classy
+
+This runs the container and passes it the api credentials via environment variables.
+The `-p` option forwards port 5001 on the host machine to port 8000 inside the container.
+The `-e` option sets an environment variable.
+The last argument is the tag we specified when building the image.
+
+    # docker run -p 5001:8000 -v "$PWD"/config.py:/src/config.py:ro -e CLASSY_CONFIG=/src/config.py classy
+
+You can also supply a config file from outside the container.
+The `-v` option mounts ./config.py into the container as /src/config.py.
+
 BUGS
 ----
 

--- a/README.md
+++ b/README.md
@@ -55,21 +55,21 @@ Docker
 
     # docker build --tag=classy .
 
-This builds a docker image containing classy and all its dependencies.
+This builds a docker image containing classy and all its dependencies,
+giving it the name 'classy'.
 
 ### Running the docker container
 
-    # docker run -p 5001:8000 -e CLASSY_CLIENT_ID=xxx -e CLASSY_CLIENT_SECRET=xxx classy
+    # docker run \
+    >  --publish 5001:8000 \
+    >  --volume "$PWD"/config.py:/src/config.py:ro \
+    >  classy
 
-This runs the container and passes it the api credentials via environment variables.
-The `-p` option forwards port 5001 on the host machine to port 8000 inside the container.
-The `-e` option sets an environment variable.
-The last argument is the tag we specified when building the image.
-
-    # docker run -p 5001:8000 -v "$PWD"/config.py:/src/config.py:ro -e CLASSY_CONFIG=/src/config.py classy
-
-You can also supply a config file from outside the container.
-The `-v` option mounts ./config.py into the container as /src/config.py.
+This runs the container and passing in a configuration file.
+(See Configuration above. Note that the dockerfile automatically sets CLASSY\_CONFIG=/src/config.py.)
+The `--publish` option forwards port 5001 on the host machine to port 8000 inside the container.
+The `--volume` option mounts ./config.py into the container as /src/config.py.
+The last argument is the tag you specified when building the image.
 
 BUGS
 ----

--- a/classy/api.py
+++ b/classy/api.py
@@ -18,7 +18,7 @@ class Client(object):
         self.client_id = app.config['CLIENT_ID']
         self.client_secret = app.config['CLIENT_SECRET']
         self.endpoint = app.config['ENDPOINT']
-        self.token_endpoint = self.endpoint + '/class-search/token'
+        self.token_endpoint = self.endpoint + '/catalog/token'
 
     def get_url(self, url, params=None):
         access_token = self.access_token
@@ -55,16 +55,16 @@ class Client(object):
         if page_number is not None:
             params['page[number]'] = page_number
 
-        return self.get_url(self.endpoint+"/class-search", params=params)
+        return self.get_url(self.endpoint+"/catalog/courses", params=params)
 
     def term(self, id):
-        return self.get_url(self.endpoint+"/terms/"+urllib.quote(id))
+        return self.get_url(self.endpoint+"/catalog/terms/"+urllib.quote(id))
 
     def open_terms(self):
-        return self.get_url(self.endpoint+"/terms/open")
+        return self.get_url(self.endpoint+"/catalog/terms/open")
 
     def subjects(self):
-        return self.get_url(self.endpoint+"/course-subjects")
+        return self.get_url(self.endpoint+"/catalog/subjects")
 
     @cached_property
     def access_token(self):

--- a/classy/docker_config.py
+++ b/classy/docker_config.py
@@ -1,0 +1,6 @@
+import os
+ENDPOINT = "https://api.oregonstate.edu/v1"
+if os.environ.get('CLASSY_ENDPOINT'):
+    ENDPOINT = os.environ.get('CLASSY_ENDPOINT')
+CLIENT_ID = os.environ.get('CLASSY_CLIENT_ID', '')
+CLIENT_SECRET = os.environ.get('CLASSY_CLIENT_SECRET', '')

--- a/classy/docker_config.py
+++ b/classy/docker_config.py
@@ -1,6 +1,0 @@
-import os
-ENDPOINT = "https://api.oregonstate.edu/v1"
-if os.environ.get('CLASSY_ENDPOINT'):
-    ENDPOINT = os.environ.get('CLASSY_ENDPOINT')
-CLIENT_ID = os.environ.get('CLASSY_CLIENT_ID', '')
-CLIENT_SECRET = os.environ.get('CLASSY_CLIENT_SECRET', '')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,21 @@
+# pip freeze
+cffi==1.7.0
+click==6.6
+cryptography==1.5
+enum34==1.1.6
+Flask==0.11.1
+gunicorn==19.6.0
+idna==2.1
+ipaddress==1.0.16
+itsdangerous==0.24
+Jinja2==2.8
+lru-dict==1.1.4
+MarkupSafe==0.23
+ndg-httpsclient==0.4.2
+pyasn1==0.1.9
+pycparser==2.14
+pyOpenSSL==16.1.0
+requests==2.11.1
+six==1.10.0
+virtualenv==15.0.3
+Werkzeug==0.11.10


### PR DESCRIPTION
- Uses [gunicorn][1] to serve the app.

- Add requirements.txt containing the output of `pip freeze`.
  Using requirements.txt allows us to separate installing the
  dependencies from installing classy in the Dockerfile,
  which is better for caching.

- Add docker_config.py, a default config file for classy which
  looks in the environment for settings.

[1]: http://gunicorn.org